### PR TITLE
Fixes issues OP-62 and OP-49

### DIFF
--- a/diksha/diksha.controller.js
+++ b/diksha/diksha.controller.js
@@ -1015,7 +1015,7 @@ let readFileWithPromise = (path) => {
 	return defer.promise;
 }
 
-let getEcarName = (id, ver) => `${id}_${ver.toFixed(1)}.ecar`;
+let getEcarName = (id, ver) => `${id}_0.0.ecar`;
 
 let doPostExtraction = (dir, file) => {
     let defer = q.defer();

--- a/diksha/diksha.controller.js
+++ b/diksha/diksha.controller.js
@@ -2,7 +2,9 @@ let q = require('q');
 let FormData = require('form-data');
 let {
     extractZip,
-    deleteDir
+    deleteDir,
+    readdir,
+    getInfo
 } = require('../../../filesdk');
 let fs = require('fs');
 var zlib =
@@ -967,38 +969,35 @@ let deleteEcarData = (dir, file) => {
 */
 
 let moveInternalFolders = (dir, fileNameAsFolder) => {
-    let folder = dir + fileNameAsFolder;
     let defer = q.defer();
-    fs.readdir(folder, (err, files) => {
-        if (err) {
-            console.log("Error 758");
-            console.log(err);
-            return defer.reject(null);
-        } else {
-            console.log(files);
-            let internalFolder = null;
-            moveFilePromises = [];
-            for (let i = 0; i < files.length; i++) {
-                console.log(folder + files[i]);
-                fs.stat(folder + files[i], (err, stats) => {
-                    if (err) {
-                        console.log(folder + files[i]);
-                        console.log("767");
-                    } else if (stats.isDirectory()) {
-                        console.log("directory found");
-                        internalFolder = files[i];
-                        moveFilePromises.push(moveFileWithPromise(folder + internalFolder, dir + 'xcontent/' + internalFolder));
-                        return defer.resolve(files[i]);
-                    }
-                });
-            }
-            q.all(moveFilePromises).then(value => {
-                return defer.resolve();
-            }).catch(e => {
-                return defer.reject(e);
-            });
-        }
-    });
+    const parent = dir + fileNameAsFolder;
+	
+	readdir(parent)
+		.then(files => {
+			const filesDetailsPromises = files.map(file => {
+				const path = parent + file;
+				return getInfo(path).then(stats => ({
+					...stats,
+					path,
+					name: file,
+					isDirectory: stats.isDirectory()
+				}));
+			});
+
+			return q.all(filesDetailsPromises);
+		})
+		.then(filesDetails => {
+			const internalFolders = filesDetails.filter(item => item.isDirectory);
+			const moveFilePromises = internalFolders.map(folder => moveFileWithPromise(folder.path, `${dir}xcontent/${folder.name}`));
+			return q.all(moveFilePromises);
+		})
+		.then(moveFileStatus => {	
+            defer.resolve();
+        })
+        .catch(e => {
+            defer.reject(e);
+        });
+
     return defer.promise;
 }
 

--- a/diksha/diksha.init.js
+++ b/diksha/diksha.init.js
@@ -7,6 +7,7 @@ let {
     extractFile
 } = require('./diksha.controller.js');
 let {
+    readdir,
     deleteDir
 } = require('../../../filesdk');
 let {
@@ -50,32 +51,16 @@ let initializeDikshaData = (path) => {
 */
 
 let processEcarFiles = (filePath) => {
-    let defer = q.defer();
-    fs.readdir(filePath, (err, files) => {
-        if (err) {
-            console.log(err);
-            return defer.reject(err);
-        } else {
-            let extractPromises = [];
-            for (let i = 0; i < files.length; i++) {
-                let file = files[i];
-                if (file.slice(file.lastIndexOf(".") + 1) === 'ecar') {
-                    extractPromises.push(extractFile(filePath, file));
-                }
-            }
-            q.allSettled(extractPromises).then(values => {
-                let statuses = values.map((value, index) => value.state);
-                let failIndex = statuses.indexOf("rejected");
-                if (failIndex > -1) {
-                    return defer.reject(values[failIndex]);
-                } else {
-                    return defer.resolve(values);
-                }
-            });
-        }
-    });
-    return defer.promise;
+    return readdir(filePath)
+        .then(files => {	
+            return files
+                .filter(file => file.endsWith('.ecar'))
+                .reduce((chainedExtractPromises, file) => {
+                    return chainedExtractPromises.then(() => extractFile(filePath, file));
+                }, q.when());
+        });
 }
+
 /*
     Adds the JSON files to BleveSearch Database
 */


### PR DESCRIPTION
Bug Number: [OP-62](https://project-sunbird.atlassian.net/browse/OP-62), [OP-49](https://project-sunbird.atlassian.net/browse/OP-49)

Issues:
- **[OP-62]** Ecar files with the **same ID** and but **different versions** do not get upgraded automatically 
- **[OP-49]** Ecar files with **different name** but **same ID** (hence, the same content) are not working properly

RCA:
- **[OP-62]** Ecar files were being identified with their ID **and** the version. This caused ecar files with the same ID but different versions to be treated as individual entities. Thus, no upgrade.
- **[OP-49]** During extraction each ecar file generates a folder with the name same as its ID, under xcontent. If the system tries to load the same ecar file again, it would try to create a folder with its ID but will find one with the same name already under xcontent. At this point it will first delete the existing folder, create a new one, move all content to it and then delete the source of the content. The issue was happening due to a race condition which caused the source to be deleted even before the data got moved.
 
Fix:
- **[OP-62]** Get rid of the version number and replace it with a generic 0.0. Also, make the ecar extraction sequential.
- **[OP-49]** Fix the control flow while moving ecar content 